### PR TITLE
export makeStateUpdater from core

### DIFF
--- a/.changeset/cuddly-scissors-run.md
+++ b/.changeset/cuddly-scissors-run.md
@@ -1,0 +1,5 @@
+---
+"@headless-tree/core": patch
+---
+
+export makeStateUpdater from core package

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,3 +31,5 @@ export * from "./utilities/remove-items-from-parents";
 
 export * from "./core/build-proxified-instance";
 export * from "./core/build-static-instance";
+
+export { makeStateUpdater } from "./utils";


### PR DESCRIPTION
This is a fix for https://github.com/lukasbach/headless-tree/issues/119

@lukasbach if you agree with the change, please approve the MR

Thanks
