### PR TITLE
Fix `aria-posinset` and `aria-level` to be 1-based indexing

### DIFF
--- a/.changeset/lovely-bikes-look.md
+++ b/.changeset/lovely-bikes-look.md
@@ -1,0 +1,5 @@
+---
+"@headless-tree/core": patch
+---
+
+Fix `aria-posinset` and `aria-level` to be 1-based indexing

--- a/packages/core/src/features/tree/feature.ts
+++ b/packages/core/src/features/tree/feature.ts
@@ -139,10 +139,10 @@ export const treeFeature: FeatureImplementation<any> = {
         ref: item.registerElement,
         role: "treeitem",
         "aria-setsize": itemMeta.setSize,
-        "aria-posinset": itemMeta.posInSet,
+        "aria-posinset": itemMeta.posInSet + 1,
         "aria-selected": "false",
         "aria-label": item.getItemName(),
-        "aria-level": itemMeta.level,
+        "aria-level": itemMeta.level + 1,
         tabIndex: item.isFocused() ? 0 : -1,
         onClick: (e: MouseEvent) => {
           item.setFocused();

--- a/packages/core/src/features/tree/tree.spec.ts
+++ b/packages/core/src/features/tree/tree.spec.ts
@@ -235,8 +235,8 @@ describe("core-feature/selections", () => {
       it("generates item props for random item", () => {
         expect(tree.instance.getItemInstance("x2").getProps()).toEqual({
           "aria-label": "x2",
-          "aria-level": 0,
-          "aria-posinset": 1,
+          "aria-level": 1,
+          "aria-posinset": 2,
           "aria-selected": "false",
           "aria-setsize": 4,
           onClick: expect.any(Function),
@@ -249,8 +249,8 @@ describe("core-feature/selections", () => {
       it("generates item props for focused", () => {
         expect(tree.instance.getItemInstance("x1").getProps()).toEqual({
           "aria-label": "x1",
-          "aria-level": 0,
-          "aria-posinset": 0,
+          "aria-level": 1,
+          "aria-posinset": 1,
           "aria-selected": "false",
           "aria-setsize": 4,
           onClick: expect.any(Function),


### PR DESCRIPTION
Thank you for making this amazing project!

This PR aims to fix some a11y related issues. According to the doc, both of these should be one-based indexes.

* [aria-posinset](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-posinset#integer)
* [aria-level](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-level#integer)

@lukasbach <!-- Please leave the mention in, so that I get a notification about the PR -->
