### PR TITLE
Fix useTree import in getting started

### DIFF
--- a/packages/docs/docs/0-root/getstarted.mdx
+++ b/packages/docs/docs/0-root/getstarted.mdx
@@ -71,7 +71,8 @@ For example, if you want drag-and-drop support and hotkeys support, import the r
 to your tree config:
 
 ```tsx
-import { useTree, dragAndDropFeature, hotkeysCoreFeature, syncDataLoaderFeature } from "@headless-tree/core";
+import { dragAndDropFeature, hotkeysCoreFeature, syncDataLoaderFeature } from "@headless-tree/core";
+import { useTree } from "@headless-tree/react";
 
 useTree({
     // ... other options


### PR DESCRIPTION
@lukasbach <!-- Please leave the mention in, so that I get a notification about the PR -->

`useTree` is exported from the `"@headless-tree/react"` entry, not the `core` entry

Thanks for this package!