### PR TITLE
Fix keyboard D&D error when no item is selected

### DIFF
--- a/.changeset/fluffy-ligers-bow.md
+++ b/.changeset/fluffy-ligers-bow.md
@@ -1,0 +1,5 @@
+---
+"@headless-tree/core": patch
+---
+
+Avoid initiating keyboard drag-and-drop when no item is selected

--- a/packages/core/src/features/keyboard-drag-and-drop/feature.ts
+++ b/packages/core/src/features/keyboard-drag-and-drop/feature.ts
@@ -119,7 +119,10 @@ const initiateDrag = <T>(
   const focusedItem = tree.getFocusedItem();
   const { canDrag } = tree.getConfig();
 
-  if (draggedItems && canDrag && !canDrag(draggedItems)) {
+  if (
+    draggedItems &&
+    (draggedItems.length === 0 || (canDrag && !canDrag(draggedItems)))
+  ) {
     return;
   }
 

--- a/packages/core/src/features/keyboard-drag-and-drop/keyboard-drag-and-drop.spec.ts
+++ b/packages/core/src/features/keyboard-drag-and-drop/keyboard-drag-and-drop.spec.ts
@@ -336,6 +336,13 @@ describe("core-feature/keyboard-drag-and-drop", () => {
         tree.expect.substate("assistiveDndState", undefined);
       });
 
+      it("doesnt drag when no items are selected", () => {
+        tree.do.hotkey("startDrag");
+        tree.item("x1").setFocused();
+        tree.expect.substate("dnd", undefined);
+        tree.expect.substate("assistiveDndState", undefined);
+      });
+
       it("skips positions during arrowing that have canDrop=false", () => {
         // note that, with mocked canDrop, non-folders are viable targets
         const canDrop = tree.mockedHandler("canDrop").mockReturnValue(true);


### PR DESCRIPTION
Currently `startDrag (Control+Shift+KeyD)` can initiate the d&d when no item is selected which result in an JS error on drop, because it assumes there is at least one item there.

https://github.com/lukasbach/headless-tree/blob/4cd03ce947c0ef1546cb79f5542e97aaacf9149a/packages/core/src/features/keyboard-drag-and-drop/feature.ts#L243

Originally I thought it is more natural to include the focused item to the `draggedItems`, however as it might be considered as a breaking change, this PR first just aims to fix the error..

In regards to the behavior of including focused item or not, there are couple of options I can come up with, but please let me know if any, thanks!
* leave as is, because developers can implement their own
* or, add an option whether or not to do so
* or, it was supposed to be included, so fix it anyways

@lukasbach <!-- Please leave the mention in, so that I get a notification about the PR -->
