### PR TITLE
Update keyboard D&D to include the focused item

### DIFF
--- a/.changeset/purple-hounds-give.md
+++ b/.changeset/purple-hounds-give.md
@@ -1,0 +1,5 @@
+---
+"@headless-tree/core": patch
+---
+
+Update keyboard drag and drop to include the focused item in the dragged items

--- a/packages/core/src/features/keyboard-drag-and-drop/feature.ts
+++ b/packages/core/src/features/keyboard-drag-and-drop/feature.ts
@@ -191,7 +191,14 @@ export const keyboardDragAndDropFeature: FeatureImplementation = {
       preventDefault: true,
       isEnabled: (tree) => !tree.getState().dnd,
       handler: (_, tree) => {
-        tree.startKeyboardDrag(tree.getSelectedItems());
+        const selectedItems = tree.getSelectedItems();
+        const focusedItem = tree.getFocusedItem();
+
+        tree.startKeyboardDrag(
+          selectedItems.includes(focusedItem)
+            ? selectedItems
+            : selectedItems.concat(focusedItem),
+        );
       },
     },
     dragUp: {

--- a/packages/core/src/features/keyboard-drag-and-drop/keyboard-drag-and-drop.spec.ts
+++ b/packages/core/src/features/keyboard-drag-and-drop/keyboard-drag-and-drop.spec.ts
@@ -49,6 +49,37 @@ describe("core-feature/keyboard-drag-and-drop", () => {
         tree.expect.substate("assistiveDndState", AssistiveDndState.Started);
       });
 
+      it("starts dragging only focused item", () => {
+        tree.item("x3").setFocused();
+        tree.do.hotkey("startDrag");
+        tree.expect.substate("dnd", {
+          draggedItems: [tree.item("x3")],
+          dragTarget: {
+            childIndex: 3,
+            dragLineIndex: 19,
+            dragLineLevel: 0,
+            insertionIndex: 2,
+            item: tree.item("x"),
+          },
+        });
+      });
+
+      it("starts dragging both selected and focused item", () => {
+        tree.do.selectMultiple("x111", "x112");
+        tree.item("x3").setFocused();
+        tree.do.hotkey("startDrag");
+        tree.expect.substate("dnd", {
+          draggedItems: [tree.item("x111"), tree.item("x112"), tree.item("x3")],
+          dragTarget: {
+            childIndex: 3,
+            dragLineIndex: 19,
+            dragLineLevel: 0,
+            insertionIndex: 2,
+            item: tree.item("x"),
+          },
+        });
+      });
+
       it("moves down 1", () => {
         tree.do.selectMultiple("x111", "x112");
         tree.do.hotkey("startDrag");
@@ -355,13 +386,13 @@ describe("core-feature/keyboard-drag-and-drop", () => {
 
       it("doesnt go below end of tree", () => {
         const lastState = {
-          draggedItems: [tree.item("x111")],
+          draggedItems: [tree.item("x111"), tree.item("x3")],
           dragTarget: {
             item: tree.item("x"),
             childIndex: 4,
             dragLineIndex: 20,
             dragLineLevel: 0,
-            insertionIndex: 4,
+            insertionIndex: 3,
           },
         };
 
@@ -378,7 +409,7 @@ describe("core-feature/keyboard-drag-and-drop", () => {
 
       it("doesnt go above top of tree", () => {
         const firstState = {
-          draggedItems: [tree.item("x111")],
+          draggedItems: [tree.item("x111"), tree.item("x1")],
           dragTarget: {
             item: tree.item("x"),
             childIndex: 0,


### PR DESCRIPTION
This PR updates keyboard D&D to include the focused item as the dragging item. [Discussion](https://github.com/lukasbach/headless-tree/pull/142#issuecomment-3152439234)

I tried both patterns to include the focused item only when there is no item selected and not, and thought it is more natural to always include it.

Related / Redo: https://github.com/lukasbach/headless-tree/pull/142

@lukasbach <!-- Please leave the mention in, so that I get a notification about the PR -->
