### PR TITLE
fix(types): Pass item type to ItemInstanceOpts as generic type

### DIFF
--- a/packages/core/src/types/core.ts
+++ b/packages/core/src/types/core.ts
@@ -93,11 +93,11 @@ type MayReturnNull<T extends (...x: any[]) => any> = (
   ...args: Parameters<T>
 ) => ReturnType<T> | null;
 
-export type ItemInstanceOpts<Key extends keyof ItemInstance<any>> = {
-  item: ItemInstance<any>;
-  tree: TreeInstance<any>;
+export type ItemInstanceOpts<T, Key extends keyof ItemInstance<any>> = {
+  item: ItemInstance<T>;
+  tree: TreeInstance<T>;
   itemId: string;
-  prev?: MayReturnNull<ItemInstance<any>[Key]>;
+  prev?: MayReturnNull<ItemInstance<T>[Key]>;
 };
 
 export type TreeInstanceOpts<Key extends keyof TreeInstance<any>> = {
@@ -131,7 +131,7 @@ export type FeatureImplementation<T = any> = {
 
   itemInstance?: {
     [key in keyof ItemInstance<T>]?: (
-      opts: ItemInstanceOpts<key>,
+      opts: ItemInstanceOpts<T, key>,
       ...args: Parameters<ItemInstance<T>[key]>
     ) => void;
   };


### PR DESCRIPTION
`ItemInstanceOpts` typed some properties as `ItemInstance<any>`.
This PR passes the kind of item as a new generic parameter.
(disclaimer: I just tried it for my use case where it seems to work fine, but not sure if it has any other effects somewhere else. I guess you or CI will tell me.)

@lukasbach <!-- Please leave the mention in, so that I get a notification about the PR -->

(btw. I think we attended Lego Mindstorms and Computergrafik at KIT together, maybe you remember me 😄)