### PR TITLE
getProps() return aria-expanded attribute for folder items

### DIFF
--- a/packages/core/src/features/tree/feature.ts
+++ b/packages/core/src/features/tree/feature.ts
@@ -144,6 +144,7 @@ export const treeFeature: FeatureImplementation<any> = {
         "aria-selected": "false",
         "aria-label": item.getItemName(),
         "aria-level": itemMeta.level + 1,
+        "aria-expanded": item.isFolder() ? item.isExpanded() : undefined,
         tabIndex: item.isFocused() ? 0 : -1,
         onClick: (e: MouseEvent) => {
           item.setFocused();


### PR DESCRIPTION
Potentially fixes #171 <!-- Replace with Issue number -->

**Disclaimer**: I didn't test the fix. This PR just gives a brief idea why it doesn't work currently. You as a maintainer can definitely judge better whether the fix is worth it, and whether you want to spend more time writing some tests and thinking about edge cases.

Explanation:
Basically when rendering a tree item, your documentation recommends to spread the props using `...item.getProps()`, but the `getProps` actually doesn't set that attribute.

Of course it's possible to workaround that on the consumer's side, and that's what we did already. But again I thought your library would benefit from that tiny improvement, as it gives a better experience for screen-reader users.

@lukasbach <!-- Please leave the mention in, so that I get a notification about the PR -->


PS Please feel free to reject the PR if you don't need it or want to do it another way yourself. 🙂 