### PR TITLE
fix: preserve valid make-child targets during drop redirection

### DIFF
--- a/.changeset/rare-mirrors-play.md
+++ b/.changeset/rare-mirrors-play.md
@@ -1,0 +1,5 @@
+---
+"@headless-tree/core": patch
+---
+
+Fix drag target resolution when a valid MakeChild target has an invalid parent target and reordering is disabled.

--- a/packages/core/src/features/drag-and-drop/drag-and-drop.spec.ts
+++ b/packages/core/src/features/drag-and-drop/drag-and-drop.spec.ts
@@ -5,6 +5,7 @@ import { selectionFeature } from "../selection/feature";
 import { ItemInstance } from "../../types/core";
 import { createOnDropHandler } from "../../utilities/create-on-drop-handler";
 import { propMemoizationFeature } from "../prop-memoization/feature";
+import { getDragTarget } from "./utils";
 
 const isItem = (item: unknown): item is ItemInstance<any> =>
   !!item && typeof item === "object" && "getId" in item;
@@ -607,6 +608,26 @@ describe("core-feature/drag-and-drop", () => {
           insertionIndex: 2,
           item: tree.item("x21"),
         });
+      });
+
+      it("does not redirect away from a valid make-child target when the parent target is invalid and reordering is disabled", async () => {
+        const testTree = await tree
+          .with({
+            canReorder: false,
+            canDrop: (_, target) => target.item.getId() === "x11",
+          })
+          .createTestCaseTree();
+
+        testTree.do.startDrag("x211");
+
+        const dragTarget = getDragTarget(
+          TestTree.dragEvent(),
+          testTree.item("x11"),
+          testTree.instance,
+          false,
+        );
+
+        expect(dragTarget.item.getId()).toBe("x11");
       });
     });
 

--- a/packages/core/src/features/drag-and-drop/utils.ts
+++ b/packages/core/src/features/drag-and-drop/utils.ts
@@ -233,6 +233,10 @@ export const getDragTarget = (
     return parentTarget;
   }
 
+  if (placement.type === PlacementType.MakeChild) {
+    return itemTarget;
+  }
+
   if (!canReorder && parent && !canBecomeSibling) {
     // TODO! this breaks in story DND/Can Drop. Maybe move this logic into a composable DragTargetStrategy[] ?
     return getDragTarget(e, parent, tree, hasDataTransferPayload, false);
@@ -240,10 +244,6 @@ export const getDragTarget = (
 
   if (!parent) {
     // Shouldn't happen, but if dropped "next" to root item, just drop it inside
-    return itemTarget;
-  }
-
-  if (placement.type === PlacementType.MakeChild) {
     return itemTarget;
   }
 


### PR DESCRIPTION
Fixes #0 <!-- Replace with Issue number -->

@lukasbach <!-- Please leave the mention in, so that I get a notification about the PR -->

https://github.com/user-attachments/assets/3061be37-29d7-4fdf-84d2-a102799a3a7f

https://github.com/user-attachments/assets/32a11904-f870-4514-9454-6f1b8e14ac22


# getDragTarget redirects away from a valid MakeChild target when the parent target is invalid and canReorder is false
`getDragTarget` seems to discard a valid `MakeChild` target in this case:

- the hovered item itself is a valid `MakeChild` target
- its parent is not a valid drop target
- `canReorder` is `false`

Expected: the current item should remain the final drop target.

Actual: `getDragTarget` recurses to the parent first, so the valid child target is lost and the drop never stabilizes on the current item.

The problematic branch seems to be the `!canReorder && parent && !canBecomeSibling` recursion running before the `PlacementType.MakeChild` return.

